### PR TITLE
fix things

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "scripts": {
     "start": "react-scripts start | npm run start-server",
-    "start-server": "PORT=3001 nodemon ./server/bin/www",
+    "start-server": "PORT=3001 nodemon ./server/app.js",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",

--- a/server/app.js
+++ b/server/app.js
@@ -80,6 +80,11 @@ app.use(session({
   })
 }));
 
+
+
+app.use('/user', userRouter)
+app.use('/product', productRouter)
+
  // catch 404 and forward to error handler
   app.use(function (req, res, next) {
     const err = new Error('File Not Found');
@@ -87,22 +92,15 @@ app.use(session({
     next(err);
   });
 
- // error handler
- // define as the last app.use callback
- app.use(function (err, req, res, next) {
-   res.status(err.status || 500);
-   res.send(err.message);
- });
-
-
-
-app.use ('/user', userRouter)
-app.use('/product', productRouter)
+// error handler
+// define as the last app.use callback
+app.use(function (err, req, res, next) {
+ res.status(err.status || 500);
+ res.send(err.message);
+});
 
 app.listen(process.env.PORT, process.env.IP, function() {
   console.log("server connected")
 })
-
-app.listen(3007)
 
 module.exports = app


### PR DESCRIPTION
huhu :)

nachdem ich die folgenden dinge gemacht hab, konnte ich die api wieder aufrufen:

1. im start script der `package.json` `bin/www` durch `app.js` ersetzt. ich weiß nicht, wozu `bin/www` gut ist, aber es scheint nichts weiter wichtiges zu tun. außerdem wird dort ein weiteres `app.listen` aufgerufen, wodurch ein fehler geworfen wird (`Port 3001 is already in use`).
2. in der `app.js` ein weiteres überflüssiges `app.listen` entfernt.
3. das wichtigste: die error handler middlewares ganz ans ende verschoben. wenn die error handler definiert werden, bevor die api selbst definiert wird, greifen die error handler immer, bevor die api jemals erreicht wird. alle `use` calls werden in der reihenfolge ihrer deklaration abgefrühstückt.